### PR TITLE
[packaging] Only BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/usb-moded.spec
+++ b/rpm/usb-moded.spec
@@ -16,7 +16,6 @@ BuildRequires: pkgconfig(libsystemd)
 BuildRequires: pkgconfig(ssu-sysinfo)
 BuildRequires: pkgconfig(dsme) >= 0.65.0
 BuildRequires: pkgconfig(sailfishaccesscontrol)
-BuildRequires: systemd
 BuildRequires: libtool
 
 Requires: lsof


### PR DESCRIPTION
We already include systemd as BuildRequires lets drop it so the right systemd
variant gets installed into the builder.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>