### PR TITLE
[appsync] Add missing sys/time.h include for APP_SYNC_DBUS

### DIFF
--- a/src/usb_moded-appsync.h
+++ b/src/usb_moded-appsync.h
@@ -30,6 +30,9 @@
 # define USB_MODED_APPSYNC_H_
 
 # include <stdbool.h>
+#ifdef APP_SYNC_DBUS
+# include <sys/time.h>
+#endif
 
 /* ========================================================================= *
  * Constants


### PR DESCRIPTION
Fixes the following:
```
/usr/bin/ld: usb_moded-usb_moded-appsync.o: in function `appsync_enumerate_usb':
usb_moded-appsync.c:(.text+0x1db): undefined reference to `timersub'
```
This happened on both glibc and musl libc under Void Linux with GCC 10.2 (which is also outdated at this point)