### PR TITLE
[systemd] fix use-after-free in control_service()

### DIFF
--- a/src/usb_moded-systemd.c
+++ b/src/usb_moded-systemd.c
@@ -132,10 +132,10 @@ EXIT:
 
     dbus_error_free(&err);
 
+    log_debug("%s(%s) -> %s", method, name, res ?: "N/A");
+
     if( rsp ) dbus_message_unref(rsp);
     if( req ) dbus_message_unref(req);
-
-    log_debug("%s(%s) -> %s", method, name, res ?: "N/A");
 
     return res != 0;
 }


### PR DESCRIPTION
According to [1], res points into rsp, a DBusMessage, so it must not be
read after rsp is un-referenced.

[1] https://dbus.freedesktop.org/doc/api/html/group__DBusMessage.html#gad8953f53ceea7de81cde792e3edd0230