### PR TITLE
[systemd] fix adbd-prepare service type

### DIFF
--- a/systemd/adbd-prepare.service
+++ b/systemd/adbd-prepare.service
@@ -8,7 +8,7 @@ Before=adbd.service
 PartOf=adbd.service
 
 [Service]
-Type=notify
+Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/sbin/adbd-functionfs.sh
 ExecStop=/bin/umount adb


### PR DESCRIPTION
adbd-functionfs.sh doesn't call systemd-notify. It doesn't even leave
any process behind. Thus, the correct type for this service is
"oneshot", not "notify".