### PR TITLE
[udev] Optionally track extcon and android_usb devices too. JB#59336

### DIFF
--- a/src/usb_moded-config-private.h
+++ b/src/usb_moded-config-private.h
@@ -68,8 +68,6 @@
 char                *config_find_mounts             (void);
 int                  config_find_sync               (void);
 char                *config_find_alt_mount          (void);
-char                *config_find_udev_path          (void);
-char                *config_find_udev_subsystem     (void);
 char                *config_check_trigger           (void);
 char                *config_get_trigger_subsystem   (void);
 char                *config_get_trigger_mode        (void);

--- a/src/usb_moded-config.c
+++ b/src/usb_moded-config.c
@@ -63,8 +63,6 @@ static int           config_validate_ip              (const char *ipadd);
 char                *config_find_mounts              (void);
 int                  config_find_sync                (void);
 char                *config_find_alt_mount           (void);
-char                *config_find_udev_path           (void);
-char                *config_find_udev_subsystem      (void);
 char                *config_check_trigger            (void);
 char                *config_get_trigger_subsystem    (void);
 char                *config_get_trigger_mode         (void);
@@ -167,20 +165,6 @@ char * config_find_alt_mount(void)
     LOG_REGISTER_CONTEXT;
 
     return config_get_conf_string(ALT_MOUNT_ENTRY, ALT_MOUNT_KEY);
-}
-
-char * config_find_udev_path(void)
-{
-    LOG_REGISTER_CONTEXT;
-
-    return config_get_conf_string(UDEV_PATH_ENTRY, UDEV_PATH_KEY);
-}
-
-char * config_find_udev_subsystem(void)
-{
-    LOG_REGISTER_CONTEXT;
-
-    return config_get_conf_string(UDEV_PATH_ENTRY, UDEV_SUBSYSTEM_KEY);
 }
 
 char * config_check_trigger(void)

--- a/src/usb_moded-config.h
+++ b/src/usb_moded-config.h
@@ -37,55 +37,113 @@
  * Constants
  * ========================================================================= */
 
-# define MODE_SETTING_ENTRY             "usbmode"
-# define MODE_SETTING_KEY               "mode"
-# define MODE_HIDE_KEY                  "hide"
-# define MODE_WHITELIST_KEY             "whitelist"
+/* [usbmode] */
+# define MODE_SETTING_ENTRY              "usbmode"
 
-# define FS_MOUNT_DEFAULT               "/dev/mmcblk0p1"
-# define FS_MOUNT_ENTRY                 "mountpoints"
-# define FS_MOUNT_KEY                   "mount"
-# define FS_SYNC_ENTRY                  "sync"
-# define FS_SYNC_KEY                    "nofua"
+# define MODE_SETTING_KEY                "mode"
+# define MODE_HIDE_KEY                   "hide"
+# define MODE_WHITELIST_KEY              "whitelist"
 
-# define ALT_MOUNT_ENTRY                "altmount"
-# define ALT_MOUNT_KEY                  "mount"
+# define FS_MOUNT_DEFAULT                "/dev/mmcblk0p1"
+# define FS_MOUNT_ENTRY                  "mountpoints"
+# define FS_MOUNT_KEY                    "mount"
+# define FS_SYNC_ENTRY                   "sync"
+# define FS_SYNC_KEY                     "nofua"
 
-# define UDEV_PATH_ENTRY                "udev"
-# define UDEV_PATH_KEY                  "path"
-# define UDEV_SUBSYSTEM_KEY             "subsystem"
+# define ALT_MOUNT_ENTRY                 "altmount"
+# define ALT_MOUNT_KEY                   "mount"
 
-# define CDROM_ENTRY                    "cdrom"
-# define CDROM_PATH_KEY                 "path"
-# define CDROM_TIMEOUT_KEY              "timeout"
+/* [udev]
+ *
+ * # Charger device tracking: enabled by default, uses 'usb' device
+ * # if present, otherwise scans for the best candidate among
+ * # all devices in 'power_supply' subsystem.
+ *
+ * charger_tracking = 1
+ * path = /sys/class/power_supply/usb
+ * subsystem = power_supply
+ *
+ * # Extcon device tracking: disabled by default. If enabled
+ * # tracks all devices in 'extcon' subsystem for USB=N changes.
+ * # In case of multiple device nodes providing conflicting
+ * # state information, device path needs to be explicitly given.
+ *
+ * extcon_tracking = 0
+ * extcon_path = null
+ * extcon_subsystem = extcon
+ *
+ * # Android usb device tracking: disabled by default. If enabled
+ * # tracks state of 'android0 device' / all devices in
+ * # 'android_usb' subsystem devices that have state property.
+ *
+ * android_tracking = 0
+ * android_path = /sys/class/android_usb/android0
+ * android_subsystem = android_usb
+ */
+# define UDEV_ENTRY                      "udev"
 
-# define TRIGGER_ENTRY                  "trigger"
-# define TRIGGER_PATH_KEY               "path"
-# define TRIGGER_UDEV_SUBSYSTEM         "udev_subsystem"
-# define TRIGGER_MODE_KEY               "mode"
-# define TRIGGER_PROPERTY_KEY           "property"
-# define TRIGGER_PROPERTY_VALUE_KEY     "value"
+# define UDEV_CHARGER_TRACKING_KEY       "charger_tracking"
+# define UDEV_CHARGER_TRACKING_FALLBACK  "1"
+# define UDEV_CHARGER_PATH_KEY           "path"
+# define UDEV_CHARGER_PATH_FALLBACK      "/sys/class/power_supply/usb"
+# define UDEV_CHARGER_SUBSYSTEM_KEY      "subsystem"
+# define UDEV_CHARGER_SUBSYSTEM_FALLBACK "power_supply"
 
-# define NETWORK_ENTRY                  "network"
-# define NETWORK_IP_KEY                 "ip"
-# define NETWORK_IP_FALLBACK            "192.168.2.15"
-# define NETWORK_INTERFACE_KEY          "interface"
-# define NETWORK_INTERFACE_FALLBACK     "usb0"
-# define NETWORK_GATEWAY_KEY            "gateway"
-# define NETWORK_GATEWAY_FALLBACK       NULL
-# define NETWORK_NAT_INTERFACE_KEY      "nat_interface"
-# define NETWORK_NAT_INTERFACE_FALLBACK NULL
-# define NETWORK_NETMASK_KEY            "netmask"
-# define NETWORK_NETMASK_FALLBACK       "255.255.255.0"
-# define NO_ROAMING_KEY                 "noroaming"
+# define UDEV_EXTCON_TRACKING_KEY        "extcon_tracking"
+# define UDEV_EXTCON_TRACKING_FALLBACK   "0"
+# define UDEV_EXTCON_PATH_KEY            "extcon_path"
+# define UDEV_EXTCON_PATH_FALLBACK       NULL
+# define UDEV_EXTCON_SUBSYSTEM_KEY       "extcon_subsystem"
+# define UDEV_EXTCON_SUBSYSTEM_FALLBACK  "extcon"
 
-# define ANDROID_ENTRY                  "android"
-# define ANDROID_MANUFACTURER_KEY       "iManufacturer"
-# define ANDROID_VENDOR_ID_KEY          "idVendor"
-# define ANDROID_PRODUCT_KEY            "iProduct"
-# define ANDROID_PRODUCT_ID_KEY         "idProduct"
+# define UDEV_ANDROID_TRACKING_KEY       "android_tracking"
+# define UDEV_ANDROID_TRACKING_FALLBACK  "0"
+# define UDEV_ANDROID_PATH_KEY           "android_path"
+# define UDEV_ANDROID_PATH_FALLBACK      "/sys/class/android_usb/android0"
+# define UDEV_ANDROID_SUBSYSTEM_KEY      "android_subsystem"
+# define UDEV_ANDROID_SUBSYSTEM_FALLBACK "android_usb"
 
-# define MODE_GROUP_ENTRY               "mode_group"
+/* For compatibility with older versions of dev package headers */
+# define UDEV_PATH_ENTRY                 UDEV_ENTRY
+# define UDEV_PATH_KEY                   UDEV_CHARGER_PATH_KEY
+# define UDEV_SUBSYSTEM_KEY              UDEV_CHARGER_SUBSYSTEM_KEY
+
+/* [cdrom] */
+# define CDROM_ENTRY                     "cdrom"
+# define CDROM_PATH_KEY                  "path"
+# define CDROM_TIMEOUT_KEY               "timeout"
+
+/* [trigger] */
+# define TRIGGER_ENTRY                   "trigger"
+# define TRIGGER_PATH_KEY                "path"
+# define TRIGGER_UDEV_SUBSYSTEM          "udev_subsystem"
+# define TRIGGER_MODE_KEY                "mode"
+# define TRIGGER_PROPERTY_KEY            "property"
+# define TRIGGER_PROPERTY_VALUE_KEY      "value"
+
+/* [network] */
+# define NETWORK_ENTRY                   "network"
+# define NETWORK_IP_KEY                  "ip"
+# define NETWORK_IP_FALLBACK             "192.168.2.15"
+# define NETWORK_INTERFACE_KEY           "interface"
+# define NETWORK_INTERFACE_FALLBACK      "usb0"
+# define NETWORK_GATEWAY_KEY             "gateway"
+# define NETWORK_GATEWAY_FALLBACK        NULL
+# define NETWORK_NAT_INTERFACE_KEY       "nat_interface"
+# define NETWORK_NAT_INTERFACE_FALLBACK  NULL
+# define NETWORK_NETMASK_KEY             "netmask"
+# define NETWORK_NETMASK_FALLBACK        "255.255.255.0"
+# define NO_ROAMING_KEY                  "noroaming"
+
+/* [android] */
+# define ANDROID_ENTRY                   "android"
+# define ANDROID_MANUFACTURER_KEY        "iManufacturer"
+# define ANDROID_VENDOR_ID_KEY           "idVendor"
+# define ANDROID_PRODUCT_KEY             "iProduct"
+# define ANDROID_PRODUCT_ID_KEY          "idProduct"
+
+/* [mode_group] */
+# define MODE_GROUP_ENTRY                "mode_group"
 
 /* ========================================================================= *
  * Types

--- a/src/usb_moded-udev.c
+++ b/src/usb_moded-udev.c
@@ -39,11 +39,73 @@
 #include <libudev.h>
 
 /* ========================================================================= *
+ * Constants
+ * ========================================================================= */
+
+// Properties present in battery devices
+#define PROP_CAPACITY  "POWER_SUPPLY_CAPACITY"
+// Properties present in charger devices
+#define PROP_ONLINE    "POWER_SUPPLY_ONLINE"
+#define PROP_TYPE      "POWER_SUPPLY_TYPE"
+#define PROP_REAL_TYPE "POWER_SUPPLY_REAL_TYPE"
+// Properties common to both battery and charger devices
+#define PROP_STATUS    "POWER_SUPPLY_STATUS"
+#define PROP_PRESENT   "POWER_SUPPLY_PRESENT"
+
+/* ========================================================================= *
  * Prototypes
  * ========================================================================= */
 
 /* ------------------------------------------------------------------------- *
- * UMUDEV
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+static const char          *umudev_pretty_string(const char *str);
+static bool                 umudev_white_p      (int ch);
+static bool                 umudev_black_p      (int ch);
+static char                *umudev_strip        (char *str);
+static char                *umudev_extract_token(char **ppos);
+static gchar               *umudev_read_textfile(const char *dirpath, const char *filename);
+static gchar               *umudev_get_config   (const char *key);
+static struct udev_device **umudev_get_devices  (const char *subsystem);
+static void                 umudev_free_devices (struct udev_device **devices);
+
+/* ------------------------------------------------------------------------- *
+ * UMUDEV_CHARGER
+ * ------------------------------------------------------------------------- */
+
+static bool     umudev_charger_set_online   (const char *online);
+static bool     umudev_charger_set_type     (const char *type);
+static void     umudev_charger_update_from  (struct udev_device *dev);
+static int      umudev_charger_get_score    (struct udev_device *dev);
+static void     umudev_charger_find_device  (void);
+static void     umudev_charger_schedule_poll(void);
+static void     umudev_charger_cancel_poll  (void);
+static gboolean umudev_charger_poll_cb      (gpointer aptr);
+static void     umudev_charger_poll_now     (void);
+
+/* ------------------------------------------------------------------------- *
+ * UMUDEV_EXTCON
+ * ------------------------------------------------------------------------- */
+
+static gchar *umudev_extcon_parse_state(const char *rawstate);
+static void   umudev_extcon_set_state  (const char *rawstate);
+static void   umudev_extcon_read_from  (const char *syspath);
+static void   umudev_extcon_update_from(struct udev_device *dev);
+static void   umudev_extcon_find_device(void);
+
+/* ------------------------------------------------------------------------- *
+ * UMUDEV_ANDROID
+ * ------------------------------------------------------------------------- */
+
+static gchar *umudev_android_parse_state(const char *rawstate);
+static void   umudev_android_set_state  (const char *rawstate);
+static void   umudev_android_read_from  (const char *syspath);
+static void   umudev_android_update_from(struct udev_device *dev);
+static void   umudev_android_find_device(void);
+
+/* ------------------------------------------------------------------------- *
+ * UMUDEV_CABLE_STATE
  * ------------------------------------------------------------------------- */
 
 static gboolean      umudev_cable_state_timer_cb   (gpointer aptr);
@@ -54,23 +116,53 @@ static cable_state_t umudev_cable_state_get        (void);
 static void          umudev_cable_state_set        (cable_state_t state);
 static void          umudev_cable_state_changed    (void);
 static void          umudev_cable_state_from_udev  (cable_state_t curr);
-static void          umudev_io_error_cb            (gpointer data);
-static gboolean      umudev_io_input_cb            (GIOChannel *iochannel, GIOCondition cond, gpointer data);
-static void          umudev_parse_properties       (struct udev_device *dev, bool initial);
-static int           umudev_score_as_power_supply  (const char *syspath);
-gboolean             umudev_init                   (void);
-void                 umudev_quit                   (void);
+
+/* ------------------------------------------------------------------------- *
+ * UMUDEV
+ * ------------------------------------------------------------------------- */
+
+static void     umudev_io_error_cb   (gpointer data);
+static gboolean umudev_io_input_cb   (GIOChannel *iochannel, GIOCondition cond, gpointer data);
+static void     umudev_evaluate_state(void);
+gboolean        umudev_init          (void);
+void            umudev_quit          (void);
 
 /* ========================================================================= *
  * Data
  * ========================================================================= */
 
 /* global variables */
-static struct udev         *umudev_object     = 0;
-static struct udev_monitor *umudev_monitor    = 0;
-static gchar               *umudev_sysname    = 0;
-static guint                umudev_watch_id   = 0;
-static bool                 umudev_in_cleanup = false;
+static struct udev         *umudev_object             = 0;
+static struct udev_monitor *umudev_monitor            = 0;
+
+/* Device monitoring: power_supply subsystem */
+static gchar               *umudev_charger_syspath    = 0;
+static gchar               *umudev_charger_subsystem  = 0;
+static gchar               *umudev_charger_online     = 0;
+static gchar               *umudev_charger_type       = 0;
+
+/* Delayed charger property refresh / state re-evaluation
+ *
+ * This is done when extcon / android_usb changes are seen.
+ * The delay needs to be long enough to cover transient android_usb
+ * DISCONNECTED states related to mode configuration changes, so
+ * that they are not interpreted as physical cable disconnects.
+ */
+static guint                umudev_charger_poll_id    = 0;
+static gint                 umudev_charger_poll_delay = 1000;
+
+/* Device monitoring: extcon subsystem */
+static gchar               *umudev_extcon_syspath     = 0;
+static gchar               *umudev_extcon_subsystem   = 0;
+static gchar               *umudev_extcon_state       = NULL;
+
+/* Device monitoring: android_usb subsystem */
+static gchar               *umudev_android_syspath    = 0;
+static gchar               *umudev_android_subsystem  = 0;
+static gchar               *umudev_android_state      = NULL;
+
+static guint                umudev_watch_id           = 0;
+static bool                 umudev_in_cleanup         = false;
 
 /** Cable state as evaluated from udev events */
 static cable_state_t umudev_cable_state_current  = CABLE_STATE_UNKNOWN;
@@ -82,11 +174,623 @@ static cable_state_t umudev_cable_state_active   = CABLE_STATE_UNKNOWN;
 static cable_state_t umudev_cable_state_previous = CABLE_STATE_UNKNOWN;
 
 /** Timer id for delaying: reported by udev -> active in usb-moded */
-static guint umudev_cable_state_timer_id = 0;
+static guint umudev_cable_state_timer_id    = 0;
 static gint  umudev_cable_state_timer_delay = -1;
 
 /* ========================================================================= *
- * cable state
+ * UTILITY
+ * ========================================================================= */
+
+static const char *umudev_pretty_string(const char *str)
+{
+    return !str ? "<null>" : !*str ? "<empty>" : str;
+}
+
+static bool umudev_white_p(int ch)
+{
+    return (ch > 0) && (ch <= 32);
+}
+
+static bool umudev_black_p(int ch)
+{
+    return (ch < 0) || (ch > 32);
+}
+
+static char *umudev_strip(char *str)
+{
+    if( str ) {
+        char *dst = str;
+        char *src = str;
+        while( umudev_white_p(*src) )
+            ++src;
+        for( ;; ) {
+            while( umudev_black_p(*src) )
+                *dst++ = *src++;
+            while( umudev_white_p(*src) )
+                ++src;
+            if( !*src )
+                break;
+            *dst++ = ' ';
+        }
+        *dst = 0;
+    }
+    return str;
+}
+
+static char *umudev_extract_token(char **ppos)
+{
+    char *beg = *ppos;
+    while( umudev_white_p(*beg) )
+        ++beg;
+    char *end = beg;
+    while( umudev_black_p(*end) )
+        ++end;
+    if( *end )
+        *end++ = 0;
+    *ppos = end;
+    return beg;
+}
+
+static gchar *umudev_read_textfile(const char *dirpath, const char *filename)
+{
+    gchar  *data = NULL;
+    if( dirpath && filename ) {
+        gchar  *path = g_strdup_printf("%s/%s", dirpath, filename);
+        if( !g_file_get_contents(path, &data, NULL, NULL) )
+            log_warning("%s: could not read file", path);
+        g_free(path);
+    }
+    return data;
+}
+
+static gchar *umudev_get_config(const char *key)
+{
+    gchar *val = config_get_conf_string(UDEV_ENTRY, key);
+    if( val ) {
+        if( !*val || !strcmp(val, "none") || !strcmp(val, "null") )
+            g_free(val), val = NULL;
+    }
+    return val;
+}
+
+static struct udev_device **umudev_get_devices(const char *subsystem)
+{
+    struct udev_device **devices = NULL;
+
+    struct udev_enumerate *list;
+    if( (list = udev_enumerate_new(umudev_object)) ) {
+        udev_enumerate_add_match_subsystem(list, subsystem);
+        udev_enumerate_scan_devices(list);
+        struct udev_list_entry *iter;
+        size_t count = 0;
+        udev_list_entry_foreach(iter, udev_enumerate_get_list_entry(list)) {
+            ++count;
+        }
+        devices = g_malloc_n(count + 1, sizeof *devices);
+        count = 0;
+        udev_list_entry_foreach(iter, udev_enumerate_get_list_entry(list)) {
+            const char *syspath = udev_list_entry_get_name(iter);
+            struct udev_device *dev =
+                udev_device_new_from_syspath(umudev_object, syspath);
+            if( dev )
+                devices[count++] = dev;
+        }
+        devices[count] = NULL;
+    }
+    return devices;
+}
+
+static void umudev_free_devices(struct udev_device **devices)
+{
+    if( devices ) {
+        for( size_t i = 0; devices[i]; ++i )
+            udev_device_unref(devices[i]);
+        g_free(devices);
+    }
+}
+
+/* ========================================================================= *
+ * UMUDEV_CHARGER
+ * ========================================================================= */
+
+static bool umudev_charger_set_online(const char *online)
+{
+    bool changed = false;
+    if( g_strcmp0(umudev_charger_online, online) ) {
+        log_debug("umudev_charger_online: %s -> %s",
+                  umudev_pretty_string(umudev_charger_online),
+                  umudev_pretty_string(online));
+        g_free(umudev_charger_online),
+            umudev_charger_online = g_strdup(online);
+        changed = true;
+    }
+    return changed;
+}
+
+static bool umudev_charger_set_type(const char *type)
+{
+    bool changed = false;
+    if( g_strcmp0(umudev_charger_type, type) ) {
+        log_debug("umudev_charger_type: %s -> %s",
+                  umudev_pretty_string(umudev_charger_type),
+                  umudev_pretty_string(type));
+        g_free(umudev_charger_type),
+            umudev_charger_type = g_strdup(type);
+        changed = true;
+    }
+    return changed;
+}
+
+static void umudev_charger_update_from(struct udev_device *dev)
+{
+    LOG_REGISTER_CONTEXT;
+
+    /* udev properties we are interested in */
+    const char *power_supply_online = 0;
+    const char *power_supply_type   = 0;
+
+    /*
+     * Check for present first as some drivers use online for when charging
+     * is enabled
+     */
+    power_supply_online = udev_device_get_property_value(dev, PROP_PRESENT);
+    if( !power_supply_online )
+        power_supply_online = udev_device_get_property_value(dev, PROP_ONLINE);
+
+    /* At least h4113 i.e. "Xperia XA2 - Dual SIM" seem to have
+     * POWER_SUPPLY_REAL_TYPE udev property with information
+     * that usb-moded expects to be in POWER_SUPPLY_TYPE prop.
+     */
+    power_supply_type = udev_device_get_property_value(dev, PROP_REAL_TYPE);
+    if( !power_supply_type )
+        power_supply_type = udev_device_get_property_value(dev, PROP_TYPE);
+
+    umudev_charger_set_online(power_supply_online);
+    umudev_charger_set_type(power_supply_type);
+
+    umudev_evaluate_state();
+}
+
+static int umudev_charger_get_score(struct udev_device *dev)
+{
+    LOG_REGISTER_CONTEXT;
+
+    int         score   = 0;
+    const char *sysname = NULL;
+
+    if( !dev )
+        goto EXIT;
+
+    if( !(sysname = udev_device_get_sysname(dev)) )
+        goto EXIT;
+
+    /* check that it is not a battery */
+    if( udev_device_get_property_value(dev, PROP_CAPACITY) )
+        goto EXIT;
+
+    /* check that it can be a charger */
+    const char *online  = udev_device_get_property_value(dev, PROP_ONLINE);
+    const char *present = udev_device_get_property_value(dev, PROP_PRESENT);
+    if( !online && !present )
+        goto EXIT;
+
+    /* try to assign a weighed score */
+
+    /* if it contains usb in the name it very likely is good */
+    if( strstr(sysname, "usb") )
+        score += 10;
+
+    /* often charger is also mentioned in the name */
+    if( strstr(sysname, "charger") )
+        score += 5;
+
+    /* present property is used to detect activity, however online is better */
+    if( online )
+        score += 10;
+
+    if( present )
+        score += 5;
+
+    /* while usb-moded does not use status, it should be present */
+    if( udev_device_get_property_value(dev, PROP_STATUS) )
+        score += 5;
+
+    /* type is used to detect if it is a cable or dedicated charger.
+     * Bonus points if it is there. */
+    if( udev_device_get_property_value(dev, PROP_TYPE) ||
+        udev_device_get_property_value(dev, PROP_REAL_TYPE) )
+        score += 10;
+EXIT:
+
+    log_debug("score: %2d; for: %s", score, umudev_pretty_string(sysname));
+
+    return score;
+}
+
+static void umudev_charger_find_device(void)
+{
+    LOG_REGISTER_CONTEXT;
+
+    gchar                  *tracking  = NULL;
+    gchar                  *syspath   = NULL;
+    gchar                  *subsystem = NULL;
+    struct udev_device     *dev       = NULL;
+
+    if( !(tracking = umudev_get_config(UDEV_CHARGER_TRACKING_KEY)) )
+        tracking = g_strdup(UDEV_CHARGER_TRACKING_FALLBACK);
+
+    log_debug("tracking=%s", umudev_pretty_string(tracking));
+
+    if( !g_strcmp0(tracking, "0") )
+        goto EXIT;
+
+    if( !(syspath = umudev_get_config(UDEV_CHARGER_PATH_KEY)) )
+        syspath = g_strdup(UDEV_CHARGER_PATH_FALLBACK);
+
+    if( syspath ) {
+        if( !(dev = udev_device_new_from_syspath(umudev_object, syspath)) )
+            log_warning("Unable to find $charger device '%s'", syspath);
+        else
+            subsystem = g_strdup(udev_device_get_subsystem(dev));
+    }
+
+    if( !subsystem ) {
+        if( !(subsystem = umudev_get_config(UDEV_CHARGER_SUBSYSTEM_KEY)) )
+            subsystem = g_strdup(UDEV_CHARGER_SUBSYSTEM_FALLBACK);
+    }
+
+    if( !subsystem ) {
+        log_warning("Unable to determine $charger subsystem.");
+        goto EXIT;
+    }
+
+    if( udev_monitor_filter_add_match_subsystem_devtype(umudev_monitor,
+                                                        subsystem,
+                                                        NULL) != 0 ) {
+        log_err("Unable to add $charger match");
+        goto EXIT;
+    }
+
+    umudev_charger_subsystem = g_strdup(subsystem);
+
+    if( !dev ) {
+        /* Explicit device was not named or found -> probe all */
+        log_debug("Trying to guess $charger device.\n");
+        struct udev_device **devices = umudev_get_devices(subsystem);
+        if( devices ) {
+            int best_score = 0;
+            int best_index = -1;
+            for( int i = 0; devices[i]; ++i ) {
+                int score = umudev_charger_get_score(devices[i]);
+                if( best_score < score ) {
+                    best_score = score;
+                    best_index = i;
+                }
+            }
+            if( best_index != -1 )
+                dev = udev_device_ref(devices[best_index]);
+            umudev_free_devices(devices);
+        }
+    }
+
+    if( dev )
+        umudev_charger_syspath = g_strdup(udev_device_get_syspath(dev));
+
+EXIT:
+    log_debug("charger device: subsystem=%s syspath=%s",
+              umudev_pretty_string(umudev_charger_subsystem),
+              umudev_pretty_string(umudev_charger_syspath));
+
+    if( dev )
+        udev_device_unref(dev);
+    g_free(subsystem);
+    g_free(syspath);
+    g_free(tracking);
+}
+
+static void umudev_charger_schedule_poll(void)
+{
+    LOG_REGISTER_CONTEXT;
+
+    if( !umudev_charger_poll_id ) {
+        umudev_charger_poll_id = g_timeout_add(umudev_charger_poll_delay,
+                                               umudev_charger_poll_cb,
+                                               NULL);
+    }
+}
+
+static void umudev_charger_cancel_poll(void)
+{
+    LOG_REGISTER_CONTEXT;
+
+    if( umudev_charger_poll_id ) {
+        g_source_remove(umudev_charger_poll_id),
+            umudev_charger_poll_id = 0;
+    }
+}
+
+static gboolean umudev_charger_poll_cb(gpointer aptr)
+{
+    LOG_REGISTER_CONTEXT;
+
+    umudev_charger_poll_id = 0;
+    umudev_charger_poll_now();
+    return G_SOURCE_REMOVE;
+}
+
+static void umudev_charger_poll_now(void)
+{
+    LOG_REGISTER_CONTEXT;
+
+    umudev_charger_cancel_poll();
+
+    struct udev_device *dev = NULL;
+
+    if( umudev_charger_syspath )
+        dev = udev_device_new_from_syspath(umudev_object,
+                                           umudev_charger_syspath);
+
+    if( dev ) {
+        umudev_charger_update_from(dev);
+        udev_device_unref(dev);
+    }
+    else {
+        umudev_evaluate_state();
+    }
+}
+
+/* ========================================================================= *
+ * UMUDEV_EXTCON
+ * ========================================================================= */
+
+static gchar *umudev_extcon_parse_state(const char *rawstate)
+{
+    /* We only need the "USB=N" part */
+    gchar *state = NULL;
+    gchar *tmp   = g_strdup(rawstate);
+    char  *pos   = tmp;
+    while( pos && *pos ) {
+        char *tok = umudev_extract_token(&pos);
+        if( !strncmp(tok, "USB=", 4) ) {
+            state = g_strdup(tok);
+            break;
+        }
+    }
+    g_free(tmp);
+    return state;
+}
+
+static void umudev_extcon_set_state(const char *rawstate)
+{
+    LOG_REGISTER_CONTEXT;
+
+    gchar *state = umudev_extcon_parse_state(rawstate);
+    if( g_strcmp0(umudev_extcon_state, state) ) {
+        log_debug("umudev_extcon_state: %s -> %s",
+                  umudev_pretty_string(umudev_extcon_state),
+                  umudev_pretty_string(state));
+        g_free(umudev_extcon_state),
+            umudev_extcon_state = state,
+            state = NULL;
+        umudev_charger_schedule_poll();
+    }
+    g_free(state);
+}
+
+static void umudev_extcon_read_from(const char *syspath)
+{
+    /* Note: cached state is intentionally left as-it-is if reported
+     *       state file does not exist / does not contain "USB=X" entry.
+     */
+    LOG_REGISTER_CONTEXT;
+    gchar *rawstate = umudev_read_textfile(syspath, "state");
+    if( rawstate )
+        umudev_extcon_set_state(rawstate);
+    g_free(rawstate);
+}
+
+static void umudev_extcon_update_from(struct udev_device *dev)
+{
+    const char *state = udev_device_get_property_value(dev, "STATE");
+    if( state )
+        umudev_extcon_set_state(state);
+}
+
+static void umudev_extcon_find_device(void)
+{
+    LOG_REGISTER_CONTEXT;
+
+    gchar                  *tracking  = NULL;
+    gchar                  *syspath   = NULL;
+    gchar                  *subsystem = NULL;
+    struct udev_device     *dev       = NULL;
+
+    if( !(tracking = umudev_get_config(UDEV_EXTCON_TRACKING_KEY)) )
+        tracking = g_strdup(UDEV_EXTCON_TRACKING_FALLBACK);
+
+    log_debug("tracking=%s", umudev_pretty_string(tracking));
+
+    if( !g_strcmp0(tracking, "0") )
+        goto EXIT;
+
+    if( !(syspath = umudev_get_config(UDEV_EXTCON_PATH_KEY)) )
+        syspath = g_strdup(UDEV_EXTCON_PATH_FALLBACK);
+
+    if( syspath ) {
+        if( !(dev = udev_device_new_from_syspath(umudev_object, syspath)) )
+            log_warning("Unable to find $extcon device '%s'", syspath);
+        else
+            subsystem = g_strdup(udev_device_get_subsystem(dev));
+    }
+
+    if( !subsystem ) {
+        if( !(subsystem = umudev_get_config(UDEV_EXTCON_SUBSYSTEM_KEY)) )
+            subsystem = g_strdup(UDEV_EXTCON_SUBSYSTEM_FALLBACK);
+    }
+
+    if( !subsystem ) {
+        log_warning("Unable to determine $extcon subsystem.");
+        goto EXIT;
+    }
+
+    if( udev_monitor_filter_add_match_subsystem_devtype(umudev_monitor,
+                                                        subsystem,
+                                                        NULL) != 0 ) {
+        log_err("Unable to add $extcon match");
+        goto EXIT;
+    }
+
+    umudev_extcon_subsystem = g_strdup(subsystem);
+
+    if( dev ) {
+        /* Explicit device was named and found -> probe it */
+        umudev_extcon_syspath = g_strdup(udev_device_get_syspath(dev));
+        umudev_extcon_read_from(umudev_extcon_syspath);
+    }
+    else {
+        /* Explicit device was not named or found -> probe all */
+        struct udev_device **devices = umudev_get_devices(subsystem);
+        if( devices ) {
+            for( size_t i = 0; devices[i]; ++i )
+                umudev_extcon_read_from(udev_device_get_syspath(devices[i]));
+            umudev_free_devices(devices);
+        }
+    }
+
+EXIT:
+    log_debug("extcon device: subsystem=%s syspath=%s",
+              umudev_pretty_string(umudev_extcon_subsystem),
+              umudev_pretty_string(umudev_extcon_syspath));
+
+    if( dev )
+        udev_device_unref(dev);
+    g_free(subsystem);
+    g_free(syspath);
+    g_free(tracking);
+}
+
+/* ========================================================================= *
+ * UMUDEV_ANDROID
+ * ========================================================================= */
+
+static gchar *umudev_android_parse_state(const char *rawstate)
+{
+    /* 'state' file ends with newline, udev properties do not */
+    return umudev_strip(g_strdup(rawstate));
+}
+
+static void umudev_android_set_state(const char *rawstate)
+{
+    LOG_REGISTER_CONTEXT;
+
+    gchar *state = umudev_android_parse_state(rawstate);
+    if( g_strcmp0(umudev_android_state, state) ) {
+        log_debug("umudev_android_state: %s -> %s",
+                  umudev_pretty_string(umudev_android_state),
+                  umudev_pretty_string(state));
+        g_free(umudev_android_state),
+            umudev_android_state = state,
+            state = NULL;
+        umudev_charger_schedule_poll();
+    }
+    g_free(state);
+}
+
+static void umudev_android_read_from(const char *syspath)
+{
+    /* Note: cached state is intentionally left as-it-is if
+     *       state file does not exist / is not readable.
+     */
+    LOG_REGISTER_CONTEXT;
+
+    gchar *rawstate = umudev_read_textfile(syspath, "state");
+    if( rawstate )
+        umudev_android_set_state(rawstate);
+    g_free(rawstate);
+}
+
+static void umudev_android_update_from(struct udev_device *dev)
+{
+    const char *state = udev_device_get_property_value(dev, "USB_STATE");
+    if( state )
+        umudev_android_set_state(state);
+}
+
+static void umudev_android_find_device(void)
+{
+    LOG_REGISTER_CONTEXT;
+
+    gchar                  *tracking  = NULL;
+    gchar                  *syspath   = NULL;
+    gchar                  *subsystem = NULL;
+    struct udev_device     *dev       = NULL;
+
+    if( !(tracking = umudev_get_config(UDEV_ANDROID_TRACKING_KEY)) )
+        tracking = g_strdup(UDEV_ANDROID_TRACKING_FALLBACK);
+
+    log_debug("tracking=%s", umudev_pretty_string(tracking));
+
+    if( !g_strcmp0(tracking, "0") )
+        goto EXIT;
+
+    if( !(syspath = umudev_get_config(UDEV_ANDROID_PATH_KEY)) )
+        syspath = g_strdup(UDEV_ANDROID_PATH_FALLBACK);
+
+    if( syspath ) {
+        if( !(dev = udev_device_new_from_syspath(umudev_object, syspath)) )
+            log_warning("Unable to find $android device '%s'", syspath);
+        else
+            subsystem = g_strdup(udev_device_get_subsystem(dev));
+    }
+
+    if( !subsystem ) {
+        if( !(subsystem = umudev_get_config(UDEV_ANDROID_SUBSYSTEM_KEY)) )
+            subsystem = g_strdup(UDEV_ANDROID_SUBSYSTEM_FALLBACK);
+    }
+
+    if( !subsystem ) {
+        log_warning("Unable to determine $android subsystem.");
+        goto EXIT;
+    }
+
+    if( udev_monitor_filter_add_match_subsystem_devtype(umudev_monitor,
+                                                        subsystem,
+                                                        NULL) != 0 ) {
+        log_err("Unable to add $android match");
+        goto EXIT;
+    }
+
+    umudev_android_subsystem = g_strdup(subsystem);
+
+    if( dev ) {
+        /* Explicit device was named and found -> probe it */
+        umudev_android_syspath = g_strdup(udev_device_get_syspath(dev));
+        umudev_android_read_from(umudev_android_syspath);
+    }
+    else {
+        /* Explicit device was not named or found -> probe all */
+        struct udev_device **devices = umudev_get_devices(subsystem);
+        if( devices ) {
+            for( size_t i = 0; devices[i]; ++i )
+                umudev_android_read_from(udev_device_get_syspath(devices[i]));
+            umudev_free_devices(devices);
+        }
+    }
+
+EXIT:
+    log_debug("android device: subsystem=%s syspath=%s",
+              umudev_pretty_string(umudev_android_subsystem),
+              umudev_pretty_string(umudev_android_syspath));
+
+    if( dev )
+        udev_device_unref(dev);
+    g_free(subsystem);
+    g_free(syspath);
+    g_free(tracking);
+}
+
+/* ========================================================================= *
+ * UMUDEV_CABLE_STATE
  * ========================================================================= */
 
 static gboolean umudev_cable_state_timer_cb(gpointer aptr)
@@ -272,7 +976,7 @@ EXIT:
 }
 
 /* ========================================================================= *
- * legacy code
+ * UMUDEV
  * ========================================================================= */
 
 static void umudev_io_error_cb(gpointer data)
@@ -306,34 +1010,46 @@ static gboolean umudev_io_input_cb(GIOChannel *iochannel, GIOCondition cond, gpo
     {
         /* This normally blocks but G_IO_IN indicates that we can read */
         struct udev_device *dev = udev_monitor_receive_device(umudev_monitor);
-        if( !dev )
-        {
+        if( !dev ) {
             /* if we get something else something bad happened stop watching to avoid busylooping */
             continue_watching = FALSE;
         }
-        else
-        {
-            /* check if it is the actual device we want to check */
-            if( !strcmp(umudev_sysname, udev_device_get_sysname(dev)) )
-            {
-                if( !strcmp(udev_device_get_action(dev), "change") )
-                {
-                    umudev_parse_properties(dev, false);
+        else {
+            const char *syspath   = udev_device_get_syspath(dev);
+            const char *subsystem = udev_device_get_subsystem(dev);
+            const char *action    = udev_device_get_action(dev);
+            log_debug("action=%s subsystem=%s syspath=%s",
+                      umudev_pretty_string(action),
+                      umudev_pretty_string(subsystem),
+                      umudev_pretty_string(syspath));
+
+            if( g_strcmp0(action, "change") ) {
+                // ignore add/remove events
+            }
+            else if( umudev_android_subsystem && !g_strcmp0(umudev_android_subsystem, subsystem) ) {
+                if( !umudev_android_syspath || !g_strcmp0(umudev_android_syspath, syspath) )
+                    umudev_android_update_from(dev);
+            }
+            else if( umudev_extcon_subsystem && !g_strcmp0(umudev_extcon_subsystem, subsystem) ) {
+                if( !umudev_extcon_syspath || !g_strcmp0(umudev_extcon_syspath, syspath) )
+                    umudev_extcon_update_from(dev);
+            }
+            else if( umudev_charger_subsystem && !g_strcmp0(umudev_charger_subsystem, subsystem) ) {
+                if( !umudev_charger_syspath || !g_strcmp0(umudev_charger_syspath, syspath) ) {
+                    umudev_charger_cancel_poll();
+                    umudev_charger_update_from(dev);
                 }
             }
-
             udev_device_unref(dev);
         }
     }
 
-    if( cond & (G_IO_ERR | G_IO_HUP | G_IO_NVAL) )
-    {
+    if( cond & (G_IO_ERR | G_IO_HUP | G_IO_NVAL) ) {
         /* Unhandled errors turn io watch to virtual busyloop too */
         continue_watching = FALSE;
     }
 
-    if( !continue_watching && umudev_watch_id )
-    {
+    if( !continue_watching && umudev_watch_id ) {
         umudev_watch_id = 0;
         log_crit("udev io watch disabled");
     }
@@ -343,19 +1059,77 @@ static gboolean umudev_io_input_cb(GIOChannel *iochannel, GIOCondition cond, gpo
     return continue_watching;
 }
 
-static void umudev_parse_properties(struct udev_device *dev, bool initial)
+static void umudev_evaluate_state(void)
 {
-    LOG_REGISTER_CONTEXT;
+    /* Start from cached charger properties */
+    const char *charger_online = umudev_charger_online;
+    const char *charger_type   = umudev_charger_type;
 
-    (void)initial;
+    /* Apply heuristics
+     *
+     * If charger online info is not available or reliable, extcon
+     * USB=N can be used as a substitute.
+     *
+     * In some devices USB=1 means that PC is connected, while in
+     * others it could be a charger too...
+     *
+     * Tracking gadget enumeration / configuration state in android_usb
+     * can be used to tell apart pc vs charger in those
+     * devices where USB=1 could be either one.
+     *
+     * Caveat: transient android_usb disconnects do occur also during
+     *         gadget configuration changes i.e. due to actions of
+     *         usb-moded itself -> processing of extcon/android_usb
+     *         changes is delayed in the hope that short lasting
+     *         transient states do not get evaluated.
+     */
 
-    /* udev properties we are interested in */
-    const char *power_supply_present = 0;
-    const char *power_supply_online  = 0;
-    const char *power_supply_type    = 0;
+    const char *override_online = NULL;
+    const char *override_type   = NULL;
 
-    /* Assume there is no usb connection until proven otherwise */
-    bool connected  = false;
+    if( umudev_extcon_state ) {
+        if( !strcmp(umudev_extcon_state, "USB=1") ) {
+            override_online = "1";
+            override_type   = "USB";
+        }
+        else if( !strcmp(umudev_extcon_state, "USB=0") ) {
+            override_type = "USB_DCP";
+        }
+    }
+
+    if( umudev_android_state ) {
+        if( !strcmp(umudev_android_state, "DISCONNECTED") ) {
+            override_type = "USB_DCP";
+        }
+        else {
+            override_type   = "USB";
+            override_online = "1";
+        }
+    }
+
+    if( override_type && g_strcmp0(override_type, charger_type) ) {
+        log_debug("override charger_type: %s -> %s",
+                  umudev_pretty_string(charger_type),
+                  umudev_pretty_string(override_type));
+        charger_type = override_type;
+    }
+
+    if( override_online && g_strcmp0(override_online, charger_online) ) {
+        log_debug("override charger_online: %s -> %s",
+                  umudev_pretty_string(charger_online),
+                  umudev_pretty_string(override_online));
+        charger_online = override_online;
+    }
+
+    /* Evaluate */
+
+    log_debug("evaluate online=%s type=%s extcon=%s android=%s",
+              umudev_pretty_string(charger_online),
+              umudev_pretty_string(charger_type),
+              umudev_pretty_string(umudev_extcon_state),
+              umudev_pretty_string(umudev_android_state));
+
+    bool connected = !g_strcmp0(charger_online, "1");
 
     /* Unless debug logging has been request via command line,
      * suppress warnings about potential property issues and/or
@@ -364,19 +1138,6 @@ static void umudev_parse_properties(struct udev_device *dev, bool initial)
      * again also in stable states).
      */
     bool warnings = log_p(LOG_DEBUG);
-
-    /*
-     * Check for present first as some drivers use online for when charging
-     * is enabled
-     */
-    power_supply_present = udev_device_get_property_value(dev, "POWER_SUPPLY_PRESENT");
-    if( !power_supply_present ) {
-        power_supply_present =
-            power_supply_online = udev_device_get_property_value(dev, "POWER_SUPPLY_ONLINE");
-    }
-
-    if( power_supply_present && !strcmp(power_supply_present, "1") )
-        connected = true;
 
     /* Transition period = Connection status derived from udev
      * events disagrees with usb-moded side bookkeeping. */
@@ -390,46 +1151,32 @@ static void umudev_parse_properties(struct udev_device *dev, bool initial)
     if( !connected ) {
         /* Handle: Disconnected */
 
-        if( warnings && !power_supply_present )
+        if( warnings && !charger_online )
             log_err("No usable power supply indicator\n");
         umudev_cable_state_from_udev(CABLE_STATE_DISCONNECTED);
     }
     else {
-        if( warnings && power_supply_online )
-            log_warning("Using online property\n");
-
-        /* At least h4113 i.e. "Xperia XA2 - Dual SIM" seem to have
-         * POWER_SUPPLY_REAL_TYPE udev property with information
-         * that usb-moded expects to be in POWER_SUPPLY_TYPE prop.
-         */
-        power_supply_type = udev_device_get_property_value(dev, "POWER_SUPPLY_REAL_TYPE");
-        if( !power_supply_type )
-            power_supply_type = udev_device_get_property_value(dev, "POWER_SUPPLY_TYPE");
         /*
          * Power supply type might not exist also :(
          * Send connected event but this will not be able
          * to discriminate between charger/cable.
          */
-        if( !power_supply_type ) {
+        if( !charger_type ) {
             if( warnings )
                 log_warning("Fallback since cable detection might not be accurate. "
                             "Will connect on any voltage on charger.\n");
             umudev_cable_state_from_udev(CABLE_STATE_PC_CONNECTED);
-            goto cleanup;
         }
-
-        log_debug("CONNECTED - POWER_SUPPLY_TYPE = %s", power_supply_type);
-
-        if( !strcmp(power_supply_type, "USB") ||
-            !strcmp(power_supply_type, "USB_CDP") ) {
+        else if( !strcmp(charger_type, "USB") ||
+                 !strcmp(charger_type, "USB_CDP") ) {
             umudev_cable_state_from_udev(CABLE_STATE_PC_CONNECTED);
         }
-        else if( !strcmp(power_supply_type, "USB_DCP") ||
-                 !strcmp(power_supply_type, "USB_HVDCP") ||
-                 !strcmp(power_supply_type, "USB_HVDCP_3") ) {
+        else if( !strcmp(charger_type, "USB_DCP") ||
+                 !strcmp(charger_type, "USB_HVDCP") ||
+                 !strcmp(charger_type, "USB_HVDCP_3") ) {
             umudev_cable_state_from_udev(CABLE_STATE_CHARGER_CONNECTED);
         }
-        else  if( !strcmp(power_supply_type, "USB_PD") ) {
+        else  if( !strcmp(charger_type, "USB_PD") ) {
             /* Looks like it is impossible to tell apart PD connections to
              * pc and chargers based on stable state property values.
              *
@@ -449,76 +1196,21 @@ static void umudev_parse_properties(struct udev_device *dev, bool initial)
             if( umudev_cable_state_current != CABLE_STATE_CHARGER_CONNECTED )
                 umudev_cable_state_from_udev(CABLE_STATE_PC_CONNECTED);
         }
-        else if( !strcmp(power_supply_type, "USB_FLOAT")) {
+        else if( !strcmp(charger_type, "USB_FLOAT") ) {
             if( !umudev_cable_state_connected() )
                 log_warning("connection type detection failed, assuming charger");
             umudev_cable_state_from_udev(CABLE_STATE_CHARGER_CONNECTED);
         }
-        else if( !strcmp(power_supply_type, "Unknown")) {
-            // nop
-            log_warning("unknown connection type reported, assuming disconnected");
+        else if( !strcmp(charger_type, "Unknown") ) {
+            log_warning("connection type 'Unknown' reported, assuming disconnected");
             umudev_cable_state_from_udev(CABLE_STATE_DISCONNECTED);
         }
         else {
             if( warnings )
-                log_warning("unhandled power supply type: %s", power_supply_type);
+                log_warning("unhandled power supply type: %s", charger_type);
             umudev_cable_state_from_udev(CABLE_STATE_DISCONNECTED);
         }
     }
-
-cleanup:
-    return;
-}
-
-static int umudev_score_as_power_supply(const char *syspath)
-{
-    LOG_REGISTER_CONTEXT;
-
-    int                 score   = 0;
-    struct udev_device *dev     = 0;
-    const char         *sysname = 0;
-
-    if( !umudev_object )
-        goto EXIT;
-
-    if( !(dev = udev_device_new_from_syspath(umudev_object, syspath)) )
-        goto EXIT;
-
-    if( !(sysname = udev_device_get_sysname(dev)) )
-        goto EXIT;
-
-    /* try to assign a weighed score */
-
-    /* check that it is not a battery */
-    if(strstr(sysname, "battery") || strstr(sysname, "BAT"))
-        goto EXIT;
-
-    /* if it contains usb in the name it very likely is good */
-    if(strstr(sysname, "usb"))
-        score = score + 10;
-
-    /* often charger is also mentioned in the name */
-    if(strstr(sysname, "charger"))
-        score = score + 5;
-
-    /* present property is used to detect activity, however online is better */
-    if(udev_device_get_property_value(dev, "POWER_SUPPLY_PRESENT"))
-        score = score + 5;
-
-    if(udev_device_get_property_value(dev, "POWER_SUPPLY_ONLINE"))
-        score = score + 10;
-
-    /* type is used to detect if it is a cable or dedicated charger.
-     * Bonus points if it is there. */
-    if(udev_device_get_property_value(dev, "POWER_SUPPLY_TYPE"))
-        score = score + 10;
-
-EXIT:
-    /* clean up */
-    if( dev )
-        udev_device_unref(dev);
-
-    return score;
 }
 
 gboolean umudev_init(void)
@@ -527,12 +1219,7 @@ gboolean umudev_init(void)
 
     gboolean                success = FALSE;
 
-    char                   *configured_device = NULL;
-    char                   *configured_subsystem = NULL;
-    struct udev_device     *dev = 0;
     GIOChannel             *iochannel = 0;
-
-    int ret = 0;
 
     /* Clear in-cleanup in case of restart */
     umudev_in_cleanup = false;
@@ -543,57 +1230,6 @@ gboolean umudev_init(void)
         goto EXIT;
     }
 
-    if( !(configured_device = config_find_udev_path()) )
-        configured_device = g_strdup("/sys/class/power_supply/usb");
-
-    if( !(configured_subsystem = config_find_udev_subsystem()) )
-        configured_subsystem = g_strdup("power_supply");
-
-    /* Try with configured / default device */
-    dev = udev_device_new_from_syspath(umudev_object, configured_device);
-
-    /* If needed, try heuristics */
-    if( !dev ) {
-        log_debug("Trying to guess $power_supply device.\n");
-
-        int    current_score = 0;
-        gchar *current_name  = 0;
-
-        struct udev_enumerate  *list;
-        struct udev_list_entry *list_entry;
-        struct udev_list_entry *first_entry;
-
-        list = udev_enumerate_new(umudev_object);
-        udev_enumerate_add_match_subsystem(list, "power_supply");
-        udev_enumerate_scan_devices(list);
-        first_entry = udev_enumerate_get_list_entry(list);
-        udev_list_entry_foreach(list_entry, first_entry) {
-            const char *name = udev_list_entry_get_name(list_entry);
-            int score = umudev_score_as_power_supply(name);
-            if( current_score < score ) {
-                g_free(current_name);
-                current_name = g_strdup(name);
-                current_score = score;
-            }
-        }
-        /* check if we found anything with some kind of score */
-        if(current_score > 0) {
-            dev = udev_device_new_from_syspath(umudev_object, current_name);
-        }
-        g_free(current_name);
-    }
-
-    /* Give up if no power supply device was found */
-    if( !dev ) {
-        log_err("Unable to find $power_supply device.");
-        /* communicate failure, mainloop will exit and call appropriate clean-up */
-        goto EXIT;
-    }
-
-    /* Cache device name */
-    umudev_sysname = g_strdup(udev_device_get_sysname(dev));
-    log_debug("device name = %s\n", umudev_sysname);
-
     /* Start monitoring for changes */
     umudev_monitor = udev_monitor_new_from_netlink(umudev_object, "udev");
     if( !umudev_monitor )
@@ -603,18 +1239,20 @@ gboolean umudev_init(void)
         goto EXIT;
     }
 
-    ret = udev_monitor_filter_add_match_subsystem_devtype(umudev_monitor,
-                                                          configured_subsystem,
-                                                          NULL);
-    if(ret != 0)
-    {
-        log_err("Udev match failed.\n");
-        goto EXIT;
+    /* Locate relevant devices */
+    umudev_charger_find_device();
+    umudev_extcon_find_device();
+    umudev_android_find_device();
+
+    if( !umudev_charger_syspath ) {
+        if( !umudev_extcon_subsystem && !umudev_android_subsystem ) {
+            log_warning("no charger device found, bailing out");
+            goto EXIT;
+        }
+        log_debug("no charger device found, using alternative sources");
     }
 
-    ret = udev_monitor_enable_receiving(umudev_monitor);
-    if(ret != 0)
-    {
+    if( udev_monitor_enable_receiving(umudev_monitor) != 0 ) {
         log_err("Failed to enable monitor recieving.\n");
         goto EXIT;
     }
@@ -623,7 +1261,9 @@ gboolean umudev_init(void)
     if( !iochannel )
         goto EXIT;
 
-    umudev_watch_id = g_io_add_watch_full(iochannel, 0, G_IO_IN, umudev_io_input_cb, NULL, umudev_io_error_cb);
+    umudev_watch_id = g_io_add_watch_full(iochannel, 0, G_IO_IN,
+                                          umudev_io_input_cb, NULL,
+                                          umudev_io_error_cb);
     if( !umudev_watch_id )
         goto EXIT;
 
@@ -631,18 +1271,12 @@ gboolean umudev_init(void)
     success = TRUE;
 
     /* check initial status */
-    umudev_parse_properties(dev, true);
+    umudev_charger_poll_now();
 
 EXIT:
     /* Cleanup local resources */
     if( iochannel )
         g_io_channel_unref(iochannel);
-
-    if( dev )
-        udev_device_unref(dev);
-
-    g_free(configured_subsystem);
-    g_free(configured_device);
 
     /* All or nothing */
     if( !success )
@@ -675,8 +1309,26 @@ void umudev_quit(void)
             umudev_object =0 ;
     }
 
-    g_free(umudev_sysname),
-        umudev_sysname = 0;
+    g_free(umudev_charger_syspath),
+        umudev_charger_syspath = 0;
+    g_free(umudev_charger_subsystem),
+        umudev_charger_subsystem = 0;
+
+    g_free(umudev_extcon_syspath),
+        umudev_extcon_syspath = 0;
+    g_free(umudev_extcon_subsystem),
+        umudev_extcon_subsystem = 0;
+
+    g_free(umudev_android_syspath),
+        umudev_android_syspath = 0;
+    g_free(umudev_android_subsystem),
+        umudev_android_subsystem = 0;
 
     umudev_cable_state_stop_timer();
+
+    umudev_extcon_set_state(NULL);
+    umudev_android_set_state(NULL);
+    umudev_charger_set_online(NULL);
+    umudev_charger_set_type(NULL);
+    umudev_charger_cancel_poll();
 }


### PR DESCRIPTION
In some devices charger power_supply device is not providing all information usb-moded needs or is not sending change notifications, which then can cause usb-moded not to react when cable is attached or removed, prompt for usb mode when charger is attached, etc.

If device has functioning usb reporting via extcon subsystem, it can be used to augment / override charger information by adding usb-moded
 configuration file with content like:

  [udev]
  extcon_tracking = 1

It is expected that there can be several extcon devices, and usb-moded tracks all of them. Usually this should not be a problem, but if conflicting usb state info is reported it might be necessary to explicitly state which device to use:

  [udev]
  extcon_tracking = 1
  extcon_path = /sys/class/extcon/devicename

It is assumed that extcon devices report pc type usb connections. If this is not the case and both charger and pc connections are reported, information from android_usb subsystem devices can be used for differentiating between charger and pc connections:

  [udev]
  extcon_tracking = 1
  android_tracking = 1

In some extreme cases it might be beneficial to make usb-moded ignore charger device altogether. That can be accomplished e.g. via:

  [udev]
  charger_tracking = 0
  extcon_tracking = 1
  android_tracking = 1

By default usb-moded should behave just like before. But scoring mechanism used for charger device selection heuristics was tweaked a bit, so in some cases it might be necessary to explicitly state which device should be tracked.

  [udev]
  path = /sys/class/power_supply/devicename

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>