### PR TITLE
interface should define either direction or add annotation for both directions

### DIFF
--- a/src/com.meego.usb_moded.xml
+++ b/src/com.meego.usb_moded.xml
@@ -80,8 +80,8 @@
       <arg name="mode" type="s"/>
     </signal>
     <signal name="sig_usb_taget_mode_config_ind">
-      <arg name="config" type="a{sv}"/>
-      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
+      <arg name="config" type="a{sv}" direction="out"/>
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
     </signal>
     <signal name="sig_usb_event_ind">
       <arg name="event" type="s"/>

--- a/src/usb_moded-dbus.c
+++ b/src/usb_moded-dbus.c
@@ -1031,8 +1031,8 @@ static const member_info_t usb_moded_members[] =
     ADD_SIGNAL(USB_MODE_TARGET_STATE_SIGNAL_NAME,
                "      <arg name=\"mode\" type=\"s\"/>\n"),
     ADD_SIGNAL(USB_MODE_TARGET_CONFIG_SIGNAL_NAME,
-               "      <arg name=\"config\" type=\"a{sv}\"/>\n"
-               "      <annotation name=\"org.qtproject.QtDBus.QtTypeName.In0\" value=\"QVariantMap\"/>\n"),
+               "      <arg name=\"config\" type=\"a{sv}\" direction=\"out\"/>\n"
+               "      <annotation name=\"org.qtproject.QtDBus.QtTypeName.Out0\" value=\"QVariantMap\"/>\n"),
     ADD_SIGNAL(USB_MODE_EVENT_SIGNAL_NAME,
                "      <arg name=\"event\" type=\"s\"/>\n"),
     ADD_SIGNAL(USB_MODE_CONFIG_SIGNAL_NAME,


### PR DESCRIPTION
The Qt6 qdbusxml2cpp seems to be more strict about annotations and complains on missing annotation for both directions.

```
$ /usr/lib/qt6/bin/qdbusxml2cpp -N -c QUsbModedInterface -p usb_moded_interface.h: /usr/include/usb-moded/com.meego.usb_moded.xml
dbus.parser: Invalid D-BUS object path '//com/meego/usb_moded' found while parsing introspection
qdbusxml2cpp: Got unknown type `a{sv}' processing '/usr/include/usb-moded/com.meego.usb_moded.xml'
You should add <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="<type>"/> to the XML description for 'config'
```

Related part of the xml looks like this:
```
    <signal name="sig_usb_taget_mode_config_ind">
      <arg name="config" type="a{sv}" />
      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
    </signal>
```

The fix should either add direction like this:
```
    <signal name="sig_usb_taget_mode_config_ind">
      <arg name="config" type="a{sv}" direction="in"/>
      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
    </signal>
```
Either add annotation for both directions.
```
    <signal name="sig_usb_taget_mode_config_ind">
      <arg name="config" type="a{sv}" />
      <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>
      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="QVariantMap"/>
    </signal>
```

My best guess is that annotations for both directions will not break anything, but I am not familiar with usb-moded code enough to be 100% sure.