### PR TITLE
[udev] Improve PD charger detection. Fixes JB#60160

### DIFF
--- a/config-static.h
+++ b/config-static.h
@@ -11,7 +11,7 @@
 #define PACKAGE_NAME "usb_moded"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "usb_moded 0.86.0+mer65"
+#define PACKAGE_STRING "usb_moded 0.86.0+mer66"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "usb_moded"
@@ -20,13 +20,13 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.86.0+mer65"
+#define PACKAGE_VERSION "0.86.0+mer66"
 
 /* Define to 1 if you have the ANSI C header files. */
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "0.86.0+mer65"
+#define VERSION "0.86.0+mer66"
 
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([usb_moded], [0.86.0+mer65])
+AC_INIT([usb_moded], [0.86.0+mer66])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AM_EXTRA_RECURSIVE_TARGETS([dbus-gmain])
 

--- a/rpm/usb-moded.spec
+++ b/rpm/usb-moded.spec
@@ -1,5 +1,5 @@
 Name:     usb-moded
-Version:  0.86.0+mer65
+Version:  0.86.0+mer66
 Release:  2
 Summary:  USB mode controller
 License:  LGPLv2

--- a/src/usb_moded-config.h
+++ b/src/usb_moded-config.h
@@ -63,12 +63,12 @@
  * path = /sys/class/power_supply/usb
  * subsystem = power_supply
  *
- * # Extcon device tracking: disabled by default. If enabled
+ * # Extcon device tracking: enabled by default. If enabled
  * # tracks all devices in 'extcon' subsystem for USB=N changes.
  * # In case of multiple device nodes providing conflicting
  * # state information, device path needs to be explicitly given.
  *
- * extcon_tracking = 0
+ * extcon_tracking = 1
  * extcon_path = null
  * extcon_subsystem = extcon
  *
@@ -90,7 +90,7 @@
 # define UDEV_CHARGER_SUBSYSTEM_FALLBACK "power_supply"
 
 # define UDEV_EXTCON_TRACKING_KEY        "extcon_tracking"
-# define UDEV_EXTCON_TRACKING_FALLBACK   "0"
+# define UDEV_EXTCON_TRACKING_FALLBACK   "1"
 # define UDEV_EXTCON_PATH_KEY            "extcon_path"
 # define UDEV_EXTCON_PATH_FALLBACK       NULL
 # define UDEV_EXTCON_SUBSYSTEM_KEY       "extcon_subsystem"

--- a/src/usb_moded-dbus.h
+++ b/src/usb_moded-dbus.h
@@ -36,9 +36,6 @@
  * Constants
  * ========================================================================= */
 
-/**
- * @credential "usb-moded::usb-moded-dbus-bind"  Credential needed to connect to the bus
- **/
 # define USB_MODE_SERVICE               "com.meego.usb_moded"
 # define USB_MODE_INTERFACE             "com.meego.usb_moded"
 # define USB_MODE_OBJECT                "/com/meego/usb_moded"

--- a/src/usb_moded.c
+++ b/src/usb_moded.c
@@ -288,8 +288,6 @@ usbmoded_get_modedata(const char *modename)
  * Note: This function should be called only from the main thread.
  *
  * @param modename  Name of mode to update
- *
- * @return Mode data object, or NULL
  */
 void
 usbmoded_refresh_modedata(const char *modename)


### PR DESCRIPTION
USB mode selector pops up when USB-PD charger is connected. This
happens because in case of PD connection usb charger power_supply
device does not provide enough information for telling apart pc
from charger.

Enable tracking of /sys/class/extcon device nodes. For phones that
report USB=1 state only on pc connection, this is enough information
for pc or charger decision.

In case of phone that report USB=1 both for pc and charger connections,
enabling also tracking of /sys/class/android_usb device nodes can help.
However this should be done via device specific configuration files as
it can cause jitter and notification noise before reaching stable state.
