### PR TITLE
[usb-moded] Do not treat unset mode equal to fallback in setters

### DIFF
--- a/src/usb_moded-control.c
+++ b/src/usb_moded-control.c
@@ -372,7 +372,10 @@ static void control_set_usb_mode(const char *mode)
     control_set_external_mode(MODE_BUSY);
 
     /* Propagate down to gadget config */
-    worker_request_hardware_mode(control_internal_mode);
+    if( !worker_request_hardware_mode(control_internal_mode) ) {
+        /* No transition work to wait for -> end MODE_BUSY immediately */
+        control_update_external_mode();
+    }
 
 EXIT:
     return;

--- a/src/usb_moded-worker.h
+++ b/src/usb_moded-worker.h
@@ -46,7 +46,7 @@ void              worker_clear_kernel_module  (void);
 const modedata_t *worker_get_usb_mode_data    (void);
 modedata_t       *worker_dup_usb_mode_data    (void);
 void              worker_set_usb_mode_data    (const modedata_t *data);
-void              worker_request_hardware_mode(const char *mode);
+bool              worker_request_hardware_mode(const char *mode);
 void              worker_clear_hardware_mode  (void);
 bool              worker_init                 (void);
 void              worker_quit                 (void);


### PR DESCRIPTION
If usb-moded is started when there is no usb cable connected, the initial transition to disconnected state is left hanging in transient "busy" state. While this does not cause any real problems, it is logically wrong and can cause confusion while analyzing other issues. Caused by mode setter functions that equate initial "no mode set" state as equal to fallback "cable disconnected" state.

Make worker mode setter functions treat unset to disconnected transition as a change, and also fix upper level functionality so that transitional "busy" state is ended immediately if / when there is no need to wait for asynchronous work to finish.