### PR TITLE
[debian] add missing build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: usb-moded
 Section: misc
 Priority: optional
 Maintainer: Philippe De Swert <philippe.de-swert@nokia.com>
-Build-Depends: debhelper (>= 5), autoconf, automake, libdbus-1-dev, libdbus-glib-1-dev, libglib2.0-dev, doxygen, libudev-dev
+Build-Depends: debhelper (>= 5), autoconf, automake, libdbus-1-dev, libdbus-glib-1-dev, libglib2.0-dev, doxygen, libudev-dev, libsystemd-dev, libkmod-dev
 Standards-Version: 3.9.1
 
 Package: usb-moded


### PR DESCRIPTION
Add libsystemd-dev and libkmod-dev as they are dependencies and might be missing in minimal system made for build only purpose (containers, microvm etc...)