### PR TITLE
Generalize FunctionFS support

### DIFF
--- a/config/dyn-modes/mtp_mode.ini
+++ b/config/dyn-modes/mtp_mode.ini
@@ -1,4 +1,4 @@
 [mode]
-name = mtp_mode
+name = mtp_ffs_mode
 module = g_ffs
 appsync = 1

--- a/src/usb_moded-dyn-config.c
+++ b/src/usb_moded-dyn-config.c
@@ -4,6 +4,7 @@
  * Copyright (c) 2011 Nokia Corporation. All rights reserved.
  * Copyright (c) 2013 - 2021 Jolla Ltd.
  * Copyright (c) 2020 Open Mobile Platform LLC.
+ * Copyright (c) 2025 Dylan Van Assche
  *
  * @author Philippe De Swert <philippe.de-swert@nokia.com>
  * @author Philippe De Swert <philippedeswert@gmail.com>
@@ -11,6 +12,7 @@
  * @author Thomas Perl <thomas.perl@jolla.com>
  * @author Slava Monich <slava.monich@jolla.com>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
+ * @author Dylan Van Assche <me@dylanvanassche.be>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the Lesser GNU General Public License
@@ -100,6 +102,9 @@ modedata_free(modedata_t *self)
 #ifdef CONNMAN
         g_free(self->connman_tethering);
 #endif
+        g_free(self->command_up);
+        g_free(self->command_down);
+        g_free(self->ffs_daemon_mountpoint);
         modedata_flush_settings(self);
         free(self);
     }
@@ -151,6 +156,9 @@ modedata_copy(const modedata_t *that)
     self->cached_gateway             = g_strdup(that->cached_gateway);
     self->cached_nat_interface       = g_strdup(that->cached_nat_interface);
     self->cached_netmask             = g_strdup(that->cached_netmask);
+    self->command_up                 = g_strdup(that->command_up);
+    self->command_down               = g_strdup(that->command_down);
+    self->ffs_daemon_mountpoint      = g_strdup(that->ffs_daemon_mountpoint);
 
 EXIT:
     return self;
@@ -275,6 +283,9 @@ modedata_load(const gchar *filename)
 #ifdef CONNMAN
     self->connman_tethering          = g_key_file_get_string(settingsfile,  MODE_OPTIONS_ENTRY, MODE_CONNMAN_TETHERING, NULL);
 #endif
+    self->command_up                 = g_key_file_get_string(settingsfile,  MODE_OPTIONS_ENTRY, MODE_COMMAND_UP, NULL);
+    self->command_down               = g_key_file_get_string(settingsfile,  MODE_OPTIONS_ENTRY, MODE_COMMAND_DOWN, NULL);
+    self->ffs_daemon_mountpoint      = g_key_file_get_string(settingsfile,  MODE_OPTIONS_ENTRY, MODE_FFS_DAEMON_MOUNTPOINT, NULL);
 
     //log_debug("Dynamic mode sysfs path = %s\n", self->sysfs_path);
     //log_debug("Dynamic mode sysfs value = %s\n", self->sysfs_value);

--- a/src/usb_moded-dyn-config.h
+++ b/src/usb_moded-dyn-config.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2011 Nokia Corporation. All rights reserved.
  * Copyright (c) 2013 - 2020 Jolla Ltd.
  * Copyright (c) 2020 Open Mobile Platform LLC.
+ * Copyright (c) 2025 Dylan Van Assche
  *
  * @author Philippe De Swert <philippe.de-swert@nokia.com>
  * @author Philippe De Swert <phdeswer@lumi.maa>
@@ -13,6 +14,7 @@
  * @author Slava Monich <slava.monich@jolla.com>
  * @author Simo Piiroinen <simo.piiroinen@jollamobile.com>
  * @author Andrew den Exter <andrew.den.exter@jolla.com>
+ * @author Dylan Van Assche <me@dylanvanassche.be>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the Lesser GNU General Public License
@@ -89,6 +91,10 @@
 #  define MODE_CONNMAN_TETHERING         "connman_tethering"
 # endif
 
+# define MODE_COMMAND_UP                 "command_up"
+# define MODE_COMMAND_DOWN               "command_down"
+# define MODE_FFS_DAEMON_MOUNTPOINT      "ffs_daemon_mountpoint"
+
 /* ========================================================================= *
  * Types
  * ========================================================================= */
@@ -128,6 +134,10 @@ typedef struct modedata_t
     gchar *cached_gateway;                 /**< Cached NETWORK_GATEWAY_KEY setting */
     gchar *cached_nat_interface;           /**< Cached NETWORK_NAT_INTERFACE_KEY setting */
     gchar *cached_netmask;                 /**< Cached NETWORK_NETMASK_KEY setting */
+
+    gchar *command_up;                     /**< Command to execute when starting an USB mode */
+    gchar *command_down;                   /**< Command to execute when stopping an USB mode */
+    gchar *ffs_daemon_mountpoint;          /**< Device mountpoint for userspace FunctionFS daemon */
 
 } modedata_t;
 

--- a/src/usb_moded-worker.c
+++ b/src/usb_moded-worker.c
@@ -73,15 +73,15 @@ static const char * const devstate_name[] = {
 
 static bool        worker_thread_p                 (void);
 bool               worker_bailing_out              (void);
-static devstate_t  worker_get_mtp_device_state     (void);
-static void        worker_unmount_mtp_device       (void);
-static bool        worker_mount_mtp_device         (void);
-static bool        worker_mode_is_mtp_mode         (const char *mode);
-static bool        worker_is_mtpd_running          (void);
-static bool        worker_mtpd_running_p           (void *aptr);
-static bool        worker_mtpd_stopped_p           (void *aptr);
-static bool        worker_stop_mtpd                (void);
-static bool        worker_start_mtpd               (void);
+static devstate_t  worker_get_ffs_device_state     (void);
+static void        worker_unmount_ffs_device       (void);
+static bool        worker_mount_ffs_device         (void);
+static bool        worker_mode_is_ffs_mode         (const char *mode);
+static bool        worker_is_ffs_daemon_running    (void);
+static bool        worker_ffs_daemon_running_p     (void *aptr);
+static bool        worker_ffs_daemon_stopped_p     (void *aptr);
+static bool        worker_run_command_down         (void);
+static bool        worker_run_command_up           (void);
 static bool        worker_switch_to_charging       (void);
 const char        *worker_get_kernel_module        (void);
 bool               worker_set_kernel_module        (const char *module);
@@ -169,16 +169,16 @@ worker_bailing_out(void)
 }
 
 /* ------------------------------------------------------------------------- *
- * MTP_DEVICE
+ * FUNCTIONFS_DEVICE
  * ------------------------------------------------------------------------- */
 
-/** Check if mtp device is mounted
+/** Check if FunctionFS device is mounted
  *
  * Returns DEVSTATE_MOUNTED / DEVSTATE_UNMOUNTED depending
- * on whether control endpoint file exists in the mtp device
+ * on whether control endpoint file exists in the FunctionFS device
  * directory.
  *
- * Note: If mtp device directory is for some reason not accessible by
+ * Note: If FunctionFS device directory is for some reason not accessible by
  *       uid=root processes and usb-moded does not have suitable DAC
  *       override permissions existance of the control endpoint file
  *       might not be determinable. In these cases DEVSTATE_UNKNOWN
@@ -190,59 +190,70 @@ worker_bailing_out(void)
  *         DEVSTATE_UNKNOWN
  */
 static devstate_t
-worker_get_mtp_device_state(void)
+worker_get_ffs_device_state(void)
 {
     LOG_REGISTER_CONTEXT;
 
     devstate_t state = DEVSTATE_UNKNOWN;
+    const modedata_t *data = worker_get_usb_mode_data();
+    gchar *path = g_strconcat("/dev/", data->ffs_daemon_mountpoint, "/ep0", NULL);
 
-    if( access("/dev/mtp/ep0", F_OK) == 0 )
+    if( access(path, F_OK) == 0 )
         state = DEVSTATE_MOUNTED;
     else if( errno == ENOENT )
         state = DEVSTATE_UNMOUNTED;
     else
-        log_warning("/dev/mtp/ep0: %m");
+        log_warning("%s: %m", path);
 
-    log_debug("mtp device state = %s", devstate_name[state]);
+    log_debug("FunctionFS device state = %s", devstate_name[state]);
+
+    g_free(path);
+
     return state;
 }
 
-/** Unmount mtp device
+/** Unmount ffs device
  */
 static void
-worker_unmount_mtp_device(void)
+worker_unmount_ffs_device(void)
 {
     LOG_REGISTER_CONTEXT;
+    const modedata_t *data = worker_get_usb_mode_data();
+    gchar *command = g_strconcat("/bin/umount ", "/dev/", data->ffs_daemon_mountpoint, NULL);
 
-    if( worker_get_mtp_device_state() != DEVSTATE_UNMOUNTED ) {
-        log_debug("unmounting mtp device");
-        common_system("/bin/umount /dev/mtp");
+    if( worker_get_ffs_device_state() != DEVSTATE_UNMOUNTED ) {
+        log_debug("unmounting FunctionFS device");
+        common_system(command);
     }
+
+    g_free (command);
 }
 
-/** Mount mtp device
+/** Mount ffs device
  *
- * Mount mtp device so that it is accessible by root and the
+ * Mount FunctionFS device so that it is accessible by root and the
  * currently active user.
  *
- * @return true if mtp device was mounted as result of call, false otherwise
+ * @return true if ffs device was mounted as result of call, false otherwise
  */
 static bool
-worker_mount_mtp_device(void)
+worker_mount_ffs_device(void)
 {
     LOG_REGISTER_CONTEXT;
 
     bool mounted = false;
+    const modedata_t *data = worker_get_usb_mode_data();
+    gchar *directory = g_strconcat("/dev/", data->ffs_daemon_mountpoint, NULL);
 
     /* Fail if control endpoint is already present */
-    if( worker_get_mtp_device_state() != DEVSTATE_UNMOUNTED ) {
-        log_err("mtp device already mounted");
+    if( worker_get_ffs_device_state() != DEVSTATE_UNMOUNTED ) {
+        log_err("FunctionFS device already mounted");
         goto EXIT;
     }
 
     /* Ensure that device directory exists */
-    if( mkdir("/dev/mtp", 0755) == -1 && errno != EEXIST ) {
-        log_err("failed to create /dev/mtp directory: %m");
+    if( mkdir(directory, 0755) == -1 && errno != EEXIST ) {
+        log_err("failed to create %s directory: %m", data->ffs_daemon_mountpoint);
         goto EXIT;
     }
 
@@ -257,143 +268,154 @@ worker_mount_mtp_device(void)
     if( pw )
         gid = pw->pw_gid;
 
-    /* Attempt to mount mtp device using root uid and primary
+    /* Attempt to mount FunctionFS device using root uid and primary
      * gid of the current user.
      */
-    char cmd[256];
-    snprintf(cmd, sizeof cmd,
-             "/bin/mount -o mode=0770,uid=0,gid=%u -t functionfs mtp /dev/mtp",
-             (unsigned)gid);
+    char command[512];
+    snprintf(command, sizeof command,
+             "/bin/mount -o mode=0770,uid=0,gid=%u -t functionfs %s /dev/%s",
+             (unsigned)gid, data->ffs_daemon_mountpoint, data->ffs_daemon_mountpoint);
 
-    log_debug("mounting mtp device");
-    if( common_system(cmd) != 0 )
+    log_debug("mounting FunctionFS device");
+    if( common_system(command) != 0 )
         goto EXIT;
 
     /* Check that control endpoint is present */
-    if( worker_get_mtp_device_state() != DEVSTATE_MOUNTED ) {
-        log_err("mtp control not mounted");
+    if( worker_get_ffs_device_state() != DEVSTATE_MOUNTED ) {
+        log_err("FunctionFS control not mounted");
         goto EXIT;
     }
 
     mounted = true;
 
 EXIT:
+    g_free (directory);
     return mounted;
 }
 
 /* ------------------------------------------------------------------------- *
- * MTP_DAEMON
+ * FUNCTIONFS_DAEMON
  * ------------------------------------------------------------------------- */
 
-/** Maximum time to wait for mtpd to start [ms]
+/** Maximum time to wait for FunctionFS daemon to start [ms]
  *
  * This needs to include time to start systemd unit
- * plus however long it might take for mtpd to scan
- * all files exposed over mtp. On a slow device with
- * lots of files it can easily take over 30 seconds,
- * especially during the 1st mtp connect after reboot.
+ * plus however long it might take for FunctionFS
+ * to start up, for example: scanning files over MTP.
+ * On a slow device with lots of files it can easily
+ * take over 30 seconds, especially during the 1st FunctionFS
+ * connect after reboot.
  *
  * Use two minutes as some kind of worst case estimate.
  */
-static unsigned worker_mtp_start_delay = 120 * 1000;
+static unsigned worker_ffs_daemon_start_delay = 120 * 1000;
 
-/** Maximum time to wait for mtpd to stop [ms]
+/** Maximum time to wait for FunctionFS daemon to stop [ms]
  *
  * This is just regular service stop. Expected to
  * take max couple of seconds, but use someting
  * in the ballbark of systemd default i.e. 15 seconds
  */
-static unsigned worker_mtp_stop_delay  =  15 * 1000;
+static unsigned worker_ffs_daemon_stop_delay  =  15 * 1000;
 
-/** Flag for: We have started mtp daemon
+/** Flag for: We have started FunctionFS daemon
  *
  * If we have issued systemd unit start, we should also
- * issue systemd unit stop even if probing for mtpd
- * presense gives negative result.
+ * issue systemd unit stop even if probing for FunctionFS
+ * daemon presense gives negative result.
  */
-static bool worker_mtp_service_started = false;
+static bool worker_ffs_daemon_service_started = false;
 
-static bool worker_mode_is_mtp_mode(const char *mode)
+static bool worker_mode_is_ffs_mode(const char *mode)
 {
     LOG_REGISTER_CONTEXT;
 
-    return mode && !strcmp(mode, "mtp_mode");
+    return mode && strstr(mode, "_ffs_mode") != NULL;
 }
 
-static bool worker_is_mtpd_running(void)
+static bool worker_is_ffs_daemon_running(void)
 {
     LOG_REGISTER_CONTEXT;
 
-    /* ep0 becomes available when /dev/mtp is mounted.
+    /* ep0 becomes available when ffs_daemon_mountpoint is mounted.
      *
-     * ep1, ep2, ep3 exist while mtp daemon is running,
+     * ep1, ep2, ep3 exist while FunctionFS daemon is running,
      * has ep0 opened and has written config data to it.
      */
     static const char * const lut[] = {
-        "/dev/mtp/ep0",
-        "/dev/mtp/ep1",
-        "/dev/mtp/ep2",
-        "/dev/mtp/ep3",
+        "ep0",
+        "ep1",
+        "ep2",
+        "ep3",
         0
     };
 
     bool ack = true;
+    const modedata_t *data = worker_get_usb_mode_data();
 
     for( size_t i = 0; lut[i]; ++i ) {
-        if( access(lut[i], F_OK) == -1 ) {
+        gchar *path = g_strconcat("/dev/", data->ffs_daemon_mountpoint, "/", lut[i], NULL);
+        if( access(path, F_OK) == -1 ) {
+            log_debug("%s", path);
             ack = false;
+            g_free (path);
             break;
-        }
+        } else
+            g_free (path);
     }
 
     return ack;
 }
 
 static bool
-worker_mtpd_running_p(void *aptr)
+worker_ffs_daemon_running_p(void *aptr)
 {
     LOG_REGISTER_CONTEXT;
 
     (void)aptr;
-    return worker_is_mtpd_running();
+    return worker_is_ffs_daemon_running();
 }
 
 static bool
-worker_mtpd_stopped_p(void *aptr)
+worker_ffs_daemon_stopped_p(void *aptr)
 {
     LOG_REGISTER_CONTEXT;
 
     (void)aptr;
-    return !worker_is_mtpd_running();
+    return !worker_is_ffs_daemon_running();
 }
 
 static bool
-worker_stop_mtpd(void)
+worker_run_command_down(void)
 {
     LOG_REGISTER_CONTEXT;
 
     bool ack = false;
+    const modedata_t *data = worker_get_usb_mode_data();
 
-    if( !worker_mtp_service_started && worker_mtpd_stopped_p(0) ) {
-        log_debug("mtp daemon is not running");
+    if( !worker_ffs_daemon_service_started && worker_ffs_daemon_stopped_p(0) ) {
+        log_debug("FunctionFS daemon is not running");
         goto SUCCESS;
     }
 
-    int rc = common_system("systemctl-user stop buteo-mtp.service");
+    if( data->command_down == NULL)
+        goto SUCCESS;
+
+    int rc = common_system(data->command_down);
     if( rc != 0 ) {
-        log_warning("failed to stop mtp daemon; exit code = %d", rc);
+        log_warning("failed to run bring-down command; exit code = %d", rc);
         goto FAILURE;
     }
 
-    /* Have succesfully stopped mtp service */
-    worker_mtp_service_started = false;
+    /* Have succesfully stopped FunctionFS daemon service */
+    worker_ffs_daemon_service_started = false;
 
-    if( common_wait(worker_mtp_stop_delay, worker_mtpd_stopped_p, 0) != WAIT_READY ) {
-        log_warning("failed to stop mtp daemon; giving up");
+    if( common_wait(worker_ffs_daemon_stop_delay, worker_ffs_daemon_stopped_p, 0) != WAIT_READY ) {
+        log_warning("failed to stop FunctionFS daemon; giving up");
         goto FAILURE;
     }
 
-    log_debug("mtp daemon has stopped");
+    log_debug("Bring-down command executed");
 
 SUCCESS:
     ack = true;
@@ -403,32 +425,37 @@ FAILURE:
 }
 
 static bool
-worker_start_mtpd(void)
+worker_run_command_up(void)
 {
     LOG_REGISTER_CONTEXT;
 
     bool ack = false;
+    const modedata_t *data = worker_get_usb_mode_data();
 
-    if( worker_mtpd_running_p(0) ) {
-        log_debug("mtp daemon is running");
+    if( data->ffs_daemon_mountpoint != NULL && worker_ffs_daemon_running_p(0) ) {
+        log_debug("FunctionFS daemon is already running");
         goto SUCCESS;
     }
 
-    /* Have attempted to start mtp service */
-    worker_mtp_service_started = true;
+    if (data->command_up == NULL)
+        goto SUCCESS;
 
-    int rc = common_system("systemctl-user start buteo-mtp.service");
+    /* Have attempted to start FunctionFS daemon service */
+    worker_ffs_daemon_service_started = true;
+
+    int rc = common_system(data->command_up);
     if( rc != 0 ) {
-        log_warning("failed to start mtp daemon; exit code = %d", rc);
+        log_warning("failed to run bring-up command; exit code = %d", rc);
         goto FAILURE;
     }
 
-    if( common_wait(worker_mtp_start_delay, worker_mtpd_running_p, 0) != WAIT_READY ) {
-        log_warning("failed to start mtp daemon; giving up");
+    /* FunctionFS requires the daemon to fully run before enabling UDC */
+    if( data->ffs_daemon_mountpoint != NULL && (common_wait(worker_ffs_daemon_start_delay, worker_ffs_daemon_running_p, 0) != WAIT_READY) ) {
+        log_warning("failed to start FunctionFS daemon; giving up");
         goto FAILURE;
     }
 
-    log_debug("mtp daemon has started");
+    log_debug("Bring-up command executed");
 
 SUCCESS:
     ack = true;
@@ -722,16 +749,15 @@ worker_switch_to_mode(const char *mode)
 
     log_debug("Cleaning up previous mode");
 
-    /* Either mtp daemon is not needed, or it must be *started* in
-     * correct phase of gadget configuration when entering mtp mode.
+    /* Either FunctionFS daemon is not needed, or it must be *started* in
+     * correct phase of gadget configuration when entering FunctionFS mode.
      *
-     * Similarly, unmount mtp device to make sure sure it gets mounted
+     * Similarly, unmount FunctionFS device to make sure sure it gets mounted
      * with appropriate uid/gid values when it is actually needed.
      */
-    worker_stop_mtpd();
-    worker_unmount_mtp_device();
-
     if( worker_get_usb_mode_data() ) {
+        worker_run_command_down();
+        worker_unmount_ffs_device();
         modesetting_leave_dynamic_mode();
         worker_set_usb_mode_data(NULL);
     }
@@ -767,11 +793,14 @@ worker_switch_to_mode(const char *mode)
         worker_set_usb_mode_data(data);
 
         /* When dealing with configfs, we can't enable UDC without
-         * already having mtpd running */
-        if( worker_mode_is_mtp_mode(mode) && configfs_in_use() ) {
-            if( !worker_mount_mtp_device() )
+         * already having FunctionFS daemon running */
+        if( worker_mode_is_ffs_mode(mode) && configfs_in_use() ) {
+            if( !worker_mount_ffs_device() )
                 goto FAILED;
-            if( !worker_start_mtpd() )
+        }
+
+        if ( configfs_in_use() ) {
+            if( !worker_run_command_up() )
                 goto FAILED;
         }
 
@@ -782,12 +811,15 @@ worker_switch_to_mode(const char *mode)
             goto FAILED;
 
         /* When dealing with android usb, it must be enabled before
-         * we can start mtpd. Assumption is that the same applies
-         * when using kernel modules. */
-        if( worker_mode_is_mtp_mode(mode) && !configfs_in_use() ) {
-            if( !worker_mount_mtp_device() )
+         * we can start FunctionFS daemon. Assumption is that the
+         * same applies when using kernel modules. */
+        if( worker_mode_is_ffs_mode(mode) && !configfs_in_use() ) {
+            if( !worker_mount_ffs_device() )
                 goto FAILED;
-            if( !worker_start_mtpd() )
+        }
+     
+        if( !configfs_in_use() ) {
+            if( !worker_run_command_down() )
                 goto FAILED;
         }
 
@@ -802,7 +834,9 @@ FAILED:
     /* Undo any changes we might have might have already done */
     if( worker_get_usb_mode_data() ) {
         log_debug("Cleaning up failed mode switch");
-        worker_stop_mtpd();
+        worker_run_command_down();
+        if( worker_mode_is_ffs_mode(mode))
+            worker_unmount_ffs_device();
         modesetting_leave_dynamic_mode();
         worker_set_usb_mode_data(NULL);
     }


### PR DESCRIPTION
usb-moded is at the moment hardcoded to buteo-mtp but usb-moded is able to handle any functionfs functionalities with this patch:

- Allow specifying the mount point of the functionfs device
- Allow specifying the command to execute for starting and stopping the user daemon like buteo-mtp.

This way, we can use other MTP daemons like uMTPrd and expand the functionality as well towards Android Open Accessory mode for Android Auto.