### PR TITLE
Allow disabling rescue mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,14 @@ AC_ARG_ENABLE([ofono], AS_HELP_STRING([--enable-ofono], [Enable ofono DBUS inter
    esac],[ofono=false])
 AM_CONDITIONAL([OFONO], [test x$ofono = xtrue])
 
+AC_ARG_ENABLE([rescue], AS_HELP_STRING([--enable-rescue], [Enable rescue mode  @<:@default=true@:>@]),
+  [case "${enableval}" in
+   yes) rescue=true ; CFLAGS="-DRESCUE $CFLAGS" ;;
+   no)  rescue=false ;;
+   *) AC_MSG_ERROR([bad value ${enableval} for --enable-rescue]) ;;
+   esac],[rescue=true])
+AM_CONDITIONAL([RESCUE], [test x$rescue = xtrue])
+
 PKG_CHECK_MODULES([DBUS], dbus-1 >= 1.8)
 PKG_CHECK_MODULES([GLIB], glib-2.0 >= 2.24.0)
 PKG_CHECK_MODULES([USB_MODED], [

--- a/src/usb_moded.c
+++ b/src/usb_moded.c
@@ -686,7 +686,12 @@ void usbmoded_probe_init_done(void)
 {
     LOG_REGISTER_CONTEXT;
 
+#ifdef RESCUE
     usbmoded_set_init_done(access(usbmoded_init_done_flagfile, F_OK) == 0);
+#else
+    /* If rescue mode is not enabled, bypass init done check */
+    usbmoded_set_init_done(true);
+#endif
 }
 
 /* ------------------------------------------------------------------------- *


### PR DESCRIPTION
Some distros have their own rescue mode builtin and launch usb-moded after initialization is complete. Therefore, no checks need to be performed anymore. Furthermore, this allows non-systemd init systems to launch usb-moded as well after initialization is complete.