### PR TITLE
Register NCM gadget for USB networking

### DIFF
--- a/src/usb_moded-configfs.c
+++ b/src/usb_moded-configfs.c
@@ -54,6 +54,7 @@
 
 #define DEFAULT_FUNCTION_MASS_STORAGE    "mass_storage.usb0"
 #define DEFAULT_FUNCTION_RNDIS           "rndis_bam.rndis"
+#define DEFAULT_FUNCTION_NCM             "ncm.usb0"
 #define DEFAULT_FUNCTION_MTP             "ffs.mtp"
 
 #define DEFAULT_RNDIS_CTRL_WCEIS         "wceis"
@@ -128,6 +129,7 @@ static gchar *GADGET_CTRL_SERIAL       = 0;
 
 static gchar *FUNCTION_MASS_STORAGE    = 0;
 static gchar *FUNCTION_RNDIS           = 0;
+static gchar *FUNCTION_NCM             = 0;
 static gchar *FUNCTION_MTP             = 0;
 
 static gchar *RNDIS_CTRL_WCEIS         = 0;
@@ -248,6 +250,9 @@ static void configfs_read_configuration(void)
         configfs_get_conf("function_rndis",
                           DEFAULT_FUNCTION_RNDIS);
 
+    FUNCTION_NCM =
+        configfs_get_conf("function_ncm",
+                          DEFAULT_FUNCTION_NCM);
     FUNCTION_MTP =
         configfs_get_conf("function_mtp",
                           DEFAULT_FUNCTION_MTP);
@@ -823,6 +828,7 @@ configfs_init(void)
     configfs_register_function(FUNCTION_MTP);
 
     /* Prep: developer_mode */
+    configfs_register_function(FUNCTION_NCM);
     configfs_register_function(FUNCTION_RNDIS);
     if( (text = mac_read_mac()) ) {
         configfs_write_file(RNDIS_CTRL_ETHADDR, text);
@@ -870,6 +876,8 @@ configfs_quit(void)
         FUNCTION_MASS_STORAGE = 0;
     g_free(FUNCTION_RNDIS),
         FUNCTION_RNDIS = 0;
+    g_free(FUNCTION_NCM),
+        FUNCTION_NCM = 0;
     g_free(FUNCTION_MTP),
         FUNCTION_MTP = 0;
 
@@ -977,6 +985,8 @@ configfs_map_function(const char *func)
         func = FUNCTION_MASS_STORAGE;
     else if( !strcmp(func, "rndis") )
         func = FUNCTION_RNDIS;
+    else if( !strcmp(func, "ncm") )
+        func = FUNCTION_NCM;
     else if( !strcmp(func, "mtp") )
         func = FUNCTION_MTP;
     else if( !strcmp(func, "ffs") ) // existing config files ...


### PR DESCRIPTION
USB networking is also possible via the NCM gadget instead of RNDIS which is considered insecure [1], but remains supported in usb-moded.

postmarketOS switched to NCM a long time ago, this patch adds support for it in usb-moded.

[1] https://lore.kernel.org/lkml/20221123124620.1387499-1-gregkh@linuxfoundation.org/t/